### PR TITLE
Favored Characters stored within FurnitureSetDetail object

### DIFF
--- a/ambr/models/furniture.py
+++ b/ambr/models/furniture.py
@@ -140,6 +140,7 @@ class FurnitureSetDetail(BaseModel):
     types: list[str]
     description: str
     furniture_items: list[FurnitureItem] = Field(alias="suiteItemList")
+    favored_npc_ids: list[int] = Field(alias="favoriteNpcList")
 
     @field_validator("icon", mode="before")
     def _convert_icon_url(cls, v: str) -> str:
@@ -160,3 +161,10 @@ class FurnitureSetDetail(BaseModel):
     @field_validator("furniture_items", mode="before")
     def _convert_furniture_items(cls, v: dict[str, dict[str, Any]]) -> list[FurnitureItem]:
         return [FurnitureItem(id=int(item_id), **v[item_id]) for item_id in v]
+    
+    @field_validator("favored_npc_ids", mode="before")
+    def _convert_favored_ids(cls, v: dict[str, dict[str, Any]]) -> list[int]:
+        if v == None:
+            return []
+        else:
+            return [int(fav_id) for fav_id in v.keys()] 

--- a/ambr/models/furniture.py
+++ b/ambr/models/furniture.py
@@ -167,7 +167,7 @@ class FurnitureSetDetail(BaseModel):
     def _convert_furniture_items(cls, v: dict[str, dict[str, Any]]) -> list[FurnitureItem]:
         return [FurnitureItem(id=int(item_id), **v[item_id]) for item_id in v]
 
-    @field_validator("favored_npc_ids", mode="before")
+    @field_validator("favorite_npcs", mode="before")
     def _convert_favored_ids(
         cls, v: dict[str, dict[str, Any]] | None
     ) -> list[FurnitureSetFavoriteNPC]:

--- a/ambr/models/furniture.py
+++ b/ambr/models/furniture.py
@@ -131,6 +131,11 @@ class FurnitureItem(BaseModel):
         return f"https://api.ambr.top/assets/UI/furniture/{v}.png"
 
 
+class FurnitureSetFavoriteNPC(BaseModel):
+    id: str
+    icon: str
+
+
 class FurnitureSetDetail(BaseModel):
     id: int
     name: str
@@ -140,7 +145,7 @@ class FurnitureSetDetail(BaseModel):
     types: list[str]
     description: str
     furniture_items: list[FurnitureItem] = Field(alias="suiteItemList")
-    favored_npc_ids: list[int] = Field(alias="favoriteNpcList")
+    favorite_npcs: list[FurnitureSetFavoriteNPC] = Field(alias="favoriteNpcList")
 
     @field_validator("icon", mode="before")
     def _convert_icon_url(cls, v: str) -> str:
@@ -161,10 +166,13 @@ class FurnitureSetDetail(BaseModel):
     @field_validator("furniture_items", mode="before")
     def _convert_furniture_items(cls, v: dict[str, dict[str, Any]]) -> list[FurnitureItem]:
         return [FurnitureItem(id=int(item_id), **v[item_id]) for item_id in v]
-    
+
     @field_validator("favored_npc_ids", mode="before")
-    def _convert_favored_ids(cls, v: dict[str, dict[str, Any]]) -> list[int]:
-        if v == None:
-            return []
-        else:
-            return [int(fav_id) for fav_id in v.keys()] 
+    def _convert_favored_ids(
+        cls, v: dict[str, dict[str, Any]] | None
+    ) -> list[FurnitureSetFavoriteNPC]:
+        return (
+            [FurnitureSetFavoriteNPC(id=id_, icon=data["icon"]) for id_, data in v.items()]
+            if v is not None
+            else []
+        )


### PR DESCRIPTION
Hello! I wrote to you on Discord a bit ago asking if there was a function to fetch the list of characters who "favor" a gift set. I didn't see it implemented anywhere, so I wrote a brief implementation that stores the IDs of the characters the set counts as favored.

When converting the data dictionary in client.py fetch_furniture_set_detail(), it converts the dictionary of character IDs and images to a list of just the IDs by checking the key 'favoriteNpcList.'

I was interested in this functionality as I was going to build an excellent way to display which furniture sets would yield the most rewards for the fewest crafts, given a list of obtained characters and an inventory of furnishings.

This is my first time contributing to an active project so I apologize if I did something wrong.

Thanks!